### PR TITLE
Lock app to portrait orientation

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
             android:label="@string/title_activity_main"
             android:theme="@style/AppTheme.NoActionBarLaunch"
             android:launchMode="singleTask"
+            android:screenOrientation="portrait"
             android:exported="true">
 
             <intent-filter>


### PR DESCRIPTION
## What

Adds `android:screenOrientation="portrait"` to the `<activity>` in `AndroidManifest.xml`.

## Why

Rotating a drawing canvas mid-session is disorienting (especially for toddlers). Portrait lock keeps the experience consistent regardless of how the phone is held.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author